### PR TITLE
거래 내역 페이지 기본 레이아웃 구현

### DIFF
--- a/src/pages/TransactionsPage.vue
+++ b/src/pages/TransactionsPage.vue
@@ -1,7 +1,212 @@
 <template>
-  <div>
-    <h1>거래 내역 페이지</h1>
+  <div class="transactions-page container py-4">
+    <!-- 헤더 영역: 제목 + 자산 정보 + 검색/필터/추가 -->
+    <h1 class="fw-bold fs-2 mt-4 mb-4">거래내역</h1>
+
+    <!-- 테이블 -->
+    <table class="table table-hover align-middle transactions-table">
+      <thead>
+        <tr>
+          <th class="checkbox-header">
+            <input type="checkbox" />
+          </th>
+          <th>분류</th>
+          <th>날짜</th>
+          <th>카테고리</th>
+          <th>금액</th>
+          <th>메모</th>
+          <th class="btn-delete-header">
+            <button class="btn btn-sm btn-outline-dark btn-delete">
+              선택삭제
+            </button>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="item in state.transactions" :key="item.id">
+          <td>
+            <input type="checkbox" />
+          </td>
+          <td class="text-center">
+            <span
+              class="badge"
+              :class="item.type === 'income' ? 'badge-income' : 'badge-expense'"
+            >
+              {{ item.type === 'income' ? '수입' : '지출' }}
+            </span>
+          </td>
+          <td class="text-body-secondary">{{ formatDate(item.date) }}</td>
+          <td>
+            <img
+              :src="getCategoryIcon(item.category)"
+              :alt="item.category"
+              class="category-icon me-1"
+            />
+            {{ item.category }}
+          </td>
+          <td
+            class="fw-semibold"
+            :class="item.type === 'income' ? 'text-income' : 'text-expense'"
+          >
+            {{ formatAmount(item) }}
+          </td>
+          <td class="text-muted">{{ item.memo }}</td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </template>
 
-<script setup></script>
+<script setup>
+import { onMounted, reactive } from 'vue';
+import axios from 'axios';
+
+// 카테고리 아이콘 매핑 (assets 이미지)
+import monthlyIncomeIcon from '@/assets/monthly_income.png';
+import allowanceIcon from '@/assets/allowance.png';
+import interestIcon from '@/assets/interest.png';
+import otherIncomeIcon from '@/assets/other_income.png';
+import foodIcon from '@/assets/food.png';
+import publicTransportIcon from '@/assets/public_transport.png';
+import costOfLivingIcon from '@/assets/cost_of_living.png';
+import shoppingIcon from '@/assets/shopping.png';
+import hospitalIcon from '@/assets/hospital.png';
+import educationIcon from '@/assets/education.png';
+import leisureIcon from '@/assets/leisure.png';
+import insuranceIcon from '@/assets/insurance.png';
+import otherExpenseIcon from '@/assets/other_expense.png';
+
+const categoryIconMap = {
+  월급: monthlyIncomeIcon,
+  용돈: allowanceIcon,
+  이자: interestIcon,
+  기타수입: otherIncomeIcon,
+  식비: foodIcon,
+  교통비: publicTransportIcon,
+  '주거/생활비': costOfLivingIcon,
+  쇼핑: shoppingIcon,
+  의료: hospitalIcon,
+  교육: educationIcon,
+  '여가/문화': leisureIcon,
+  보험: insuranceIcon,
+  기타지출: otherExpenseIcon,
+};
+
+function getCategoryIcon(category) {
+  return categoryIconMap[category] || otherExpenseIcon;
+}
+
+const BASE_URL = 'http://localhost:3000';
+const state = reactive({ transactions: [], selectedIds: [] });
+
+async function fetchTransactions() {
+  try {
+    const { data } = await axios.get(`${BASE_URL}/transactions`);
+    state.transactions = data;
+  } catch (err) {
+    console.log(err);
+  }
+}
+
+onMounted(() => {
+  fetchTransactions();
+});
+
+function formatDate(dateStr) {
+  const [y, m, d] = dateStr.split('-');
+  return `${y}년 ${parseInt(m)}월 ${parseInt(d)}일`;
+}
+
+function formatAmount(item) {
+  const sign = item.type === 'expense' ? '-' : '';
+  return `${sign}₩${item.amount.toLocaleString()}`;
+}
+</script>
+
+<style scoped>
+/* 카테고리 아이콘 */
+.category-icon {
+  width: 14px;
+  height: 14px;
+  vertical-align: middle;
+  object-fit: contain;
+}
+
+/* 분류 뱃지 */
+.badge-expense {
+  background-color: #ffe5e5;
+  color: #e74c3c;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.35em 0.85em;
+  border-radius: 4px;
+}
+.badge-income {
+  background-color: #e5ffe5;
+  color: #2ecc71;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.35em 0.85em;
+  border-radius: 4px;
+}
+
+/* 색상 */
+.text-expense {
+  color: #e74c3c;
+}
+.text-income {
+  color: #2ecc71;
+}
+
+/* 테이블 스타일 */
+.transactions-table thead th {
+  background-color: #fafafa;
+  font-weight: 700;
+  font-size: 1.025rem;
+  color: #6d6d6d;
+  padding: 0.75rem 0.5rem;
+  text-align: center;
+  border-top: 1px solid #ddd;
+  border-bottom: 1px solid #ddd;
+}
+
+.transactions-table thead th:first-child {
+  border-left: 1px solid #ddd;
+}
+
+.transactions-table thead th:last-child {
+  border-right: 1px solid #ddd;
+}
+
+.transactions-table tbody td {
+  font-size: 0.875rem;
+  padding: 0.75rem 0.5rem;
+  vertical-align: middle;
+  text-align: center;
+}
+
+.transactions-table tbody tr {
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.transactions-table tbody tr:hover {
+  background-color: #fffdf5;
+}
+
+/* 체크박스 */
+.checkbox-header {
+  width: 40px;
+}
+
+/* 선택삭제 버튼 */
+.btn-delete-header {
+  width: 80px;
+}
+.btn-delete {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: #6d6d6d;
+  border-color: #aeaeae;
+}
+</style>


### PR DESCRIPTION
## 기능 개요
- closes #12

## 작업 상세 내용

- [x] 거래내역 페이지 기본 레이아웃 구현
- [x] json-server와 데이터 연동 기능 구현

## 참고자료

<img width="2878" height="1530" alt="transaction-기본-화면" src="https://github.com/user-attachments/assets/5226fcc3-6bd6-41a7-be48-d098936e2a23" />


## 문제점 혹은 고민
- 테이블 스타일을 디자인과 똑같이 하기 어려운 부분이 있어서 조금 수정했습니다.
    - 특히 테이블 상단 모서리 둥글게 하는게 생각보다 어렵네요...