### PR TITLE
feat: 카테고리별 지출 도넛 차트 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,10 @@
       "dependencies": {
         "axios": "^1.14.0",
         "bootstrap": "^5.3.8",
+        "chart.js": "^4.5.1",
         "pinia": "^3.0.4",
         "vue": "^3.5.30",
+        "vue-chartjs": "^5.3.3",
         "vue-router": "^5.0.3"
       },
       "devDependencies": {
@@ -964,6 +966,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
@@ -1812,6 +1820,18 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/chokidar": {
       "version": "5.0.0",
@@ -3146,6 +3166,16 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-chartjs": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-5.3.3.tgz",
+      "integrity": "sha512-jqxtL8KZ6YJ5NTv6XzrzLS7osyegOi28UGNZW0h9OkDL7Sh1396ht4Dorh04aKrl2LiSalQ84WtqiG0RIJb0tA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "vue": "^3.0.0-0 || ^2.7.0"
       }
     },
     "node_modules/vue-router": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "axios": "^1.14.0",
     "bootstrap": "^5.3.8",
+    "chart.js": "^4.5.1",
     "pinia": "^3.0.4",
     "vue": "^3.5.30",
+    "vue-chartjs": "^5.3.3",
     "vue-router": "^5.0.3"
   },
   "devDependencies": {

--- a/src/components/report/ReportCategoryChart.vue
+++ b/src/components/report/ReportCategoryChart.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="chart-wrapper">
+    <Doughnut :data="chartData" :options="chartOptions" />
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { Doughnut } from 'vue-chartjs';
+import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
+
+ChartJS.register(ArcElement, Tooltip, Legend);
+
+const props = defineProps({
+  expenseByCategory: {
+    type: Array,
+    required: true,
+  },
+});
+
+const chartData = computed(() => {
+  return {
+    labels: props.expenseByCategory.map((item) => item.category),
+    datasets: [
+      {
+        data: props.expenseByCategory.map((item) => item.amount),
+        backgroundColor: [
+          '#FF6384',
+          '#36A2EB',
+          '#FFCE56',
+          '#4BC0C0',
+          '#9966FF',
+          '#FF9F40',
+          '#8DD17E',
+          '#C9CBCF',
+        ],
+        borderWidth: 1,
+      },
+    ],
+  };
+});
+
+const chartOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: {
+    legend: {
+      position: 'right',
+    },
+  },
+};
+</script>
+
+<style scoped>
+.chart-wrapper {
+  width: 100%;
+  max-width: 600px;
+  height: 320px;
+}
+</style>

--- a/src/pages/ReportPage.vue
+++ b/src/pages/ReportPage.vue
@@ -14,6 +14,11 @@
 
     <hr />
 
+    <h2>카테고리별 지출 차트</h2>
+    <ReportCategoryChart :expenseByCategory="expenseByCategory" />
+
+    <hr />
+
     <ul>
       <li v-for="item in filteredTransactions" :key="item.id">
         {{ item.date }} / {{ item.type }} / {{ item.category }} /
@@ -35,6 +40,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue';
 import axios from 'axios';
+import ReportCategoryChart from '@/components/report/ReportCategoryChart.vue';
 
 const transactions = ref([]);
 const selectedMonth = ref('2026-04');


### PR DESCRIPTION
## 기능 개요
- closes #24

> 카테고리별 지출 데이터를 기반으로 도넛 차트를 추가

## 작업 상세 내용

- [x] Chart.js 및 vue-chartjs 라이브러리 설치
- [x] ReportCategoryChart 컴포넌트 생성
- [x] expenseByCategory 데이터를 props로 전달받아 차트 데이터로 변환

## 참고자료(선택)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0a89ac8c-83b0-4a57-9d55-220a030fc0a8" />


## 문제점 혹은 고민(선택)