### PR TITLE
feat: 차트 하단 거래내역 리스트 구현

### DIFF
--- a/src/components/report/ReportCategoryChart.vue
+++ b/src/components/report/ReportCategoryChart.vue
@@ -7,10 +7,17 @@
 <script setup>
 import { computed } from 'vue';
 import { Doughnut } from 'vue-chartjs';
-import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
+import {
+  Chart as ChartJS,
+  ArcElement,
+  Tooltip,
+  Legend,
+  elements,
+} from 'chart.js';
 
 ChartJS.register(ArcElement, Tooltip, Legend);
 
+const emit = defineEmits(['select-category']);
 const props = defineProps({
   expenseByCategory: {
     type: Array,
@@ -43,6 +50,13 @@ const chartData = computed(() => {
 const chartOptions = {
   responsive: true,
   maintainAspectRatio: false,
+  onClick: (event, elements) => {
+    if (!elements.length) return;
+
+    const clickedIndex = elements[0].index;
+    const clickedCategory = props.expenseByCategory[clickedIndex].category;
+    emit('select-category', clickedCategory);
+  },
   plugins: {
     legend: {
       position: 'right',

--- a/src/pages/ReportPage.vue
+++ b/src/pages/ReportPage.vue
@@ -15,23 +15,24 @@
     <hr />
 
     <h2>카테고리별 지출 차트</h2>
-    <ReportCategoryChart :expenseByCategory="expenseByCategory" />
+    <ReportCategoryChart
+      :expenseByCategory="expenseByCategory"
+      @select-category="handleSelectCategory"
+    />
 
     <hr />
 
-    <ul>
-      <li v-for="item in filteredTransactions" :key="item.id">
-        {{ item.date }} / {{ item.type }} / {{ item.category }} /
-        {{ item.amount.toLocaleString() }}원
-      </li>
-    </ul>
+    <h2>
+      {{
+        selectedCategory ? `${selectedCategory} 거래 내역` : '최근 거래 내역'
+      }}
+    </h2>
 
-    <hr />
-
-    <h2>카테고리별 지출 합계</h2>
     <ul>
-      <li v-for="item in expenseByCategory" :key="item.category">
-        {{ item.category }} : {{ item.amount.toLocaleString() }}원
+      <li v-for="item in displayedTransactions" :key="item.id">
+        {{ item.date }} / {{ item.category }} / {{ item.memo }} /
+        {{ item.type === 'expense' ? '-' : '+'
+        }}{{ item.amount.toLocaleString() }}원
       </li>
     </ul>
   </div>
@@ -44,6 +45,7 @@ import ReportCategoryChart from '@/components/report/ReportCategoryChart.vue';
 
 const transactions = ref([]);
 const selectedMonth = ref('2026-04');
+const selectedCategory = ref(null);
 
 const fetchTransactions = async () => {
   try {
@@ -107,6 +109,28 @@ const expenseByCategory = computed(() => {
     amount,
   }));
 });
+
+//하단 카테고리별 거래내역
+const displayedTransactions = computed(() => {
+  let result = filteredTransactions.value.filter(
+    (item) => item.type === 'expense',
+  );
+
+  if (selectedCategory.value) {
+    result = result.filter((item) => item.category === selectedCategory.value);
+  }
+
+  return result.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+});
+
+//차트 조각 클릭 이벤트
+const handleSelectCategory = (category) => {
+  if (selectedCategory.value === category) {
+    selectedCategory.value = null;
+    return;
+  }
+  selectedCategory.value = category;
+};
 
 onMounted(() => {
   fetchTransactions();


### PR DESCRIPTION
## 기능 개요
- closes #31 

> 차트 조각 클릭 시 해당 카테고리의 거래만 필터링되어 리스트 표시되도록 구현. (초기 상태에서는 전체 거래 내역 표시)

## 작업 상세 내용

- [x] selectedCategory 상태 추가 및 카테고리 선택 로직 구현
- [x] 차트 클릭 시 선택된 카테고리를 부모 컴포넌트로 전달하도록 이벤트 연결
- [x] displayedTransactions computed를 통해 카테고리별 필터링 및 최신순 정렬 구현
- [x] 동일 카테고리 재클릭 시 필터 해제 기능 구현

## 참고자료(선택)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/44791228-11fc-4b94-ab42-8164a5c440cd" />


## 문제점 혹은 고민(선택)