### PR TITLE
거래내역 페이지에 한달 자산이 표시되지 않는 문제 해결

### DIFF
--- a/src/pages/TransactionsPage.vue
+++ b/src/pages/TransactionsPage.vue
@@ -5,7 +5,7 @@
       <h1 class="fw-bold fs-2 mt-4 mb-4">거래내역</h1>
       <div class="header-actions">
         <span class="asset-info"
-          >자산 · ₩{{ store.totalAsset.toLocaleString() }} · 1개월 변동</span
+          >자산 · ₩{{ store.balance.toLocaleString() }} · 1개월 변동</span
         >
         <input
           v-model="store.searchQuery"

--- a/src/stores/transactions.js
+++ b/src/stores/transactions.js
@@ -180,13 +180,6 @@ export const useTransactionStore = defineStore('transactions', () => {
   // 거래내역 페이지용 계산된 값
   // ───────────────────────────────
 
-  // 자산 합계
-  const totalAsset = computed(() => {
-    return transactions.value.reduce((sum, t) => {
-      return t.type === 'income' ? sum + t.amount : sum - t.amount;
-    }, 0);
-  });
-
   const filteredTransactions = computed(() => {
     let list = [...transactions.value];
 
@@ -296,7 +289,6 @@ export const useTransactionStore = defineStore('transactions', () => {
     resetFilter,
 
     // 계산된 값
-    totalAsset,
     filteredTransactions,
     monthlyIncome,
     monthlyExpense,


### PR DESCRIPTION
## 버그 개요
- closes #73 

## 해결 과정

- 거래 내역 페이지에서 "1개월 변동" 옆에 한달 자산을 보여줄 때 전체 기간의 자산을 보여주는 문제가 있었습니다.
- transactions.js에서 balacne가 있어서 해당 computed variable를 사용하도록 했습니다.
- 더 이상 사용되지 않는 totalAsset은 삭제했습니다.