### PR TITLE
거래내역 페이지 스타일 개선

### DIFF
--- a/src/pages/TransactionsPage.vue
+++ b/src/pages/TransactionsPage.vue
@@ -934,18 +934,24 @@ onBeforeUnmount(() => {
   }
 
   .search-input {
-    flex: 1 1 auto;
+    flex: 1 1 0;
     min-width: 0;
     width: auto;
+    max-width: 140px;
+    height: 34px;
+    font-size: 0.78rem;
+    padding: 0 10px;
   }
 
   .btn-action {
-    padding: 0 14px;
-    font-size: 0.78rem;
+    flex-shrink: 0;
+    padding: 0 12px;
+    height: 34px;
+    font-size: 0.75rem;
   }
 
   .btn-add {
-    padding: 0 16px;
+    padding: 0 14px;
   }
 
   /* 페이지네이션: 위아래 여백 확대 */

--- a/src/pages/TransactionsPage.vue
+++ b/src/pages/TransactionsPage.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="container py-4 transactions-page">
+  <div class="container py-2 transactions-page">
     <!-- 헤더 영역: 제목 + 자산 정보 + 검색/필터/추가 -->
     <div class="header-row">
-      <h1 class="fw-bold fs-2 mt-4 mb-4">거래내역</h1>
+      <h1 class="fw-bold fs-2">거래내역</h1>
       <div class="header-actions">
         <span class="asset-info"
           >자산 · ₩{{ store.balance.toLocaleString() }} · 1개월 변동</span
@@ -457,6 +457,7 @@ onBeforeUnmount(() => {
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 12px;
+  margin: 1rem 0 1rem;
 }
 
 .header-actions {
@@ -910,7 +911,7 @@ onBeforeUnmount(() => {
     flex-direction: column;
     align-items: stretch;
     gap: 8px;
-    margin-bottom: 18px;
+    margin: 0.25rem 0 0.5rem;
   }
 
   .transactions-page h1 {


### PR DESCRIPTION
## 기능 개요
- closes #95
- closes #96 

> 거래내역 페이지 스타일 개선

## 작업 상세 내용

- [x] 태블릿 크기의 화면에서 header-row 와 table 사이에 여백이 사라지는 문제 해결
- [x] "거래내역" 타이틀 위 아래 여백이 header-row 가 아닌 h1태그에 적용되어서 일관성을 해치는 문제 해결
- [x] 검색 입력 필드가 모바일 기준 과도하게 커지는 현상 방지

## 참고자료

### 1. 화면 크기에 따른 여백 변화

### Before

![transaction-spacing-before](https://github.com/user-attachments/assets/0150b7eb-66c9-4fbf-b3b0-2fb0e0ef7f8e)


### After

![transaction-spacing-after](https://github.com/user-attachments/assets/741aded2-f4ed-40b0-b322-5f1dcd5e97c8)


### 2. 모바일 화면 검색 필드 크기 변화

### Before

<img width="2880" height="1704" alt="mobile-search-input-before" src="https://github.com/user-attachments/assets/24fad299-c71e-43f1-9386-bfb48a88aef9" />

### After

<img width="2806" height="1702" alt="mobile-search-input-after" src="https://github.com/user-attachments/assets/3ca068b6-9c45-4bb7-88a3-514937437635" />
