### PR TITLE
feat:로고 이미지 축소

### DIFF
--- a/src/components/common/Header.vue
+++ b/src/components/common/Header.vue
@@ -176,7 +176,7 @@ onBeforeUnmount(() => {
 }
 
 .logo-image {
-  height: 55px;
+  height: 48px;
   width: auto;
   max-width: 200px;
   object-fit: contain;


### PR DESCRIPTION
기능 개요
- closes #99 
로고 크기 약간 축소

작업 상세 내용

참고자료
before
<img width="1196" height="420" alt="image" src="https://github.com/user-attachments/assets/9d0ea22c-83a9-4bd2-b031-f187351560dd" />
after
<img width="1336" height="608" alt="image" src="https://github.com/user-attachments/assets/c542442b-1fa6-400f-930e-3feea4b1f27f" />
