### PR TITLE
배포환경에서 json-server의 URL을 커스텀해서 사용할 수 있도록 환경변수 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ __screenshots__/
 
 # Vite
 *.timestamp-*-*.mjs
+
+# Environment Variables
+.env
+.env.development
+.env.production

--- a/src/components/common/AddTransactionModal.vue
+++ b/src/components/common/AddTransactionModal.vue
@@ -164,6 +164,7 @@ import leisureIcon from '@/assets/leisure.png';
 import insuranceIcon from '@/assets/insurance.png';
 import otherExpenseIcon from '@/assets/other_expense.png';
 
+const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 const store = useTransactionStore();
 const props = defineProps({ isOpen: Boolean });
 const emit = defineEmits(['close', 'saved']);
@@ -270,7 +271,7 @@ const handleSave = async () => {
     const dateStr = `${selectedYear.value}-${String(
       selectedMonth.value
     ).padStart(2, '0')}-${String(selectedDay.value).padStart(2, '0')}`;
-    const res = await axios.post('http://localhost:3000/transactions', {
+    const res = await axios.post(`${BASE_URL}/transactions`, {
       userId: '1',
       type: type.value === '지출' ? 'expense' : 'income',
       date: dateStr,

--- a/src/components/common/ModifyTransactionModal.vue
+++ b/src/components/common/ModifyTransactionModal.vue
@@ -161,6 +161,7 @@ import leisureIcon from '@/assets/leisure.png';
 import insuranceIcon from '@/assets/insurance.png';
 import otherExpenseIcon from '@/assets/other_expense.png';
 
+const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 const store = useTransactionStore();
 // ── Props / Emits ──
 const props = defineProps({
@@ -284,7 +285,7 @@ const handleSave = async () => {
       selectedMonth.value
     ).padStart(2, '0')}-${String(selectedDay.value).padStart(2, '0')}`;
     const res = await axios.put(
-      `http://localhost:3000/transactions/${props.transaction.id}`,
+      `${BASE_URL}/transactions/${props.transaction.id}`,
       {
         type: type.value === '지출' ? 'expense' : 'income',
         date: dateStr,

--- a/src/stores/transactions.js
+++ b/src/stores/transactions.js
@@ -15,7 +15,7 @@ import other_income from '@/assets/other_income.png';
 import public_transport from '@/assets/public_transport.png';
 import shopping from '@/assets/shopping.png';
 
-const BASE_URL = 'http://localhost:3000';
+const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 export const useTransactionStore = defineStore('transactions', () => {
   // 서버에서 받아온 전체 거래내역
@@ -72,7 +72,7 @@ export const useTransactionStore = defineStore('transactions', () => {
     const updatedItem = res.data;
 
     const index = transactions.value.findIndex(
-      (item) => item.id === updatedItem.id,
+      (item) => item.id === updatedItem.id
     );
 
     if (index !== -1) {
@@ -168,7 +168,7 @@ export const useTransactionStore = defineStore('transactions', () => {
 
   // 전월 대비 지출 차이
   const expenseGap = computed(
-    () => monthlyExpense.value - lastMonthExpense.value,
+    () => monthlyExpense.value - lastMonthExpense.value
   );
 
   // 최근 거래내역 (id 높은 순 = 최신순)

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -2,6 +2,8 @@ import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import axios from 'axios';
 
+const BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
 const DEFAULT_IMAGE =
   'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/158.png';
 
@@ -18,7 +20,7 @@ export const useUserStore = defineStore('user', () => {
   async function fetchUser() {
     if (user.value.id) return; // 이미 불러왔으면 스킵
     try {
-      const res = await axios.get('http://localhost:3000/users/1');
+      const res = await axios.get(`${BASE_URL}/users/1`);
       const u = res.data;
       user.value = {
         id: u.id,
@@ -37,7 +39,7 @@ export const useUserStore = defineStore('user', () => {
 
   async function updateUser(form) {
     try {
-      await axios.put('http://localhost:3000/users/1', {
+      await axios.put(`${BASE_URL}/users/1`, {
         id: '1',
         name: form.name,
         email: form.email,


### PR DESCRIPTION
## 기능 개요
- closes #98 

> 배포 환경에서 json-server 활용을 위한 환경변수 설정

## 작업 상세 내용

- [x] 수정모달과 추가모달, store들에서 하드코딩된 URL을 환경변수로 수정

## 참고자료

### 배포 환경 
- 이제 https://wallet-guardian.site 로 접속하면 우리 모두의 공유 가계부를 확인할 수 있습니다.

![wallet-guardian-deploy-https](https://github.com/user-attachments/assets/3fbd0ff9-b0c8-4052-a3d3-ab08ce2d969d)
