### PR TITLE
거래내역 페이지 필터, 메모 관련 버그 수정

### DIFF
--- a/src/pages/TransactionsPage.vue
+++ b/src/pages/TransactionsPage.vue
@@ -440,6 +440,7 @@ onBeforeUnmount(() => {
   if (mobileMediaQuery) {
     mobileMediaQuery.removeEventListener('change', updateIsMobile);
   }
+  store.resetFilter();
 });
 </script>
 

--- a/src/pages/TransactionsPage.vue
+++ b/src/pages/TransactionsPage.vue
@@ -200,7 +200,7 @@
             >
               {{ formatAmount(item) }}
             </td>
-            <td class="text-muted">{{ item.memo }}</td>
+            <td class="text-muted memo-cell">{{ item.memo }}</td>
             <td></td>
           </tr>
         </tbody>
@@ -601,6 +601,12 @@ onBeforeUnmount(() => {
   padding: 0.75rem 0.5rem;
   vertical-align: middle;
   text-align: center;
+}
+
+.memo-cell {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .transactions-table tbody tr {


### PR DESCRIPTION
## 기능 개요
- closes #103 
- closes #104 

> 거래내역 페이지에 존재하는 자잘한 버그 수정

## 작업 상세 내용

- [x] 거래내역 페이지를 unMount할 때 필터 초기화
- [x] memo 길이가 길어졌을 때 elipsis 적용

## 참고자료

### 1. 필터 개선

### Before
![filter-malfunction-before](https://github.com/user-attachments/assets/de6177dd-a1b1-4e28-b6e7-e93b75423f26)

### After
![filter-malfunction-after](https://github.com/user-attachments/assets/a1891ac9-6e85-4a68-89e4-d48f8793fb7b)

### 2. 메모 개선

### Before
<img width="2766" height="1142" alt="memo-overflow-before" src="https://github.com/user-attachments/assets/65136f47-2264-4297-83ac-e445f00b283c" />

### After
<img width="2658" height="1134" alt="memo-overflow-after" src="https://github.com/user-attachments/assets/be84f356-db1c-4ed7-a9df-7639e57d6328" />

